### PR TITLE
Improvements to functionality

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Denis Francesconi, Hydro Quebec
+Jonathan Fether, Momentum Data Systems
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to

--- a/PMQtest.js
+++ b/PMQtest.js
@@ -11,10 +11,9 @@ mq.open({
     msgsize: 8
 });
 var writebuf = new Buffer(1);
-var r;
 do {
     writebuf[0] = Math.floor(Math.random() * 93) + 33;
     console.log("Writing "+ writebuf[0] +" ('"+ String.fromCharCode(writebuf[0]) +"') to the queue...");
-} while ((r = mq.push(writebuf)) !== false);
+} while (mq.push(writebuf) !== false);
     mq.unlink();
     mq.close();

--- a/PMQtest.js
+++ b/PMQtest.js
@@ -11,9 +11,10 @@ mq.open({
     msgsize: 8
 });
 var writebuf = new Buffer(1);
+var r;
 do {
     writebuf[0] = Math.floor(Math.random() * 93) + 33;
     console.log("Writing "+ writebuf[0] +" ('"+ String.fromCharCode(writebuf[0]) +"') to the queue...");
-} while (mq.push(writebuf) !== false);
+} while ((r = mq.push(writebuf)) !== false);
     mq.unlink();
     mq.close();

--- a/PosixMQ-read.js
+++ b/PosixMQ-read.js
@@ -36,7 +36,7 @@ module.exports = function (RED) {
       }
 
       node.status({ fill: "green", shape: "dot", text: config.msgname });
-      readbuf = new Buffer(posixmq.msgsize);
+      var readbuf = Buffer.alloc(posixmq.msgsize);
 
       posixmq.on('messages', () => {
          var n;

--- a/PosixMQ-read.js
+++ b/PosixMQ-read.js
@@ -38,13 +38,17 @@ module.exports = function (RED) {
       node.status({ fill: "green", shape: "dot", text: config.msgname });
       var readbuf = Buffer.alloc(posixmq.msgsize);
 
-      posixmq.on('messages', () => {
+      var readMsg = () => {
          var n;
          while ((n = posixmq.shift(readbuf)) !== false) {
             var str = readbuf.toString('utf8', 0, n);
             node.send({ payload: str });
          }
-      });
+      }
+
+      posixmq.on('messages', readMsg);
+      readMsg();
+
       node.on('close', () => {
          posixmq.close();
          node.status({ fill: "red", shape: "dot", text: config.msgname });

--- a/PosixMQ-write.html
+++ b/PosixMQ-write.html
@@ -1,5 +1,5 @@
 <script type="text/javascript">
-    RED.nodes.registerType('posixmq-read',{
+    RED.nodes.registerType('posixmq-write',{
         category: 'function',
         color: '#a6bbcf',
         defaults: {
@@ -8,15 +8,15 @@
             maxmsgs: {value:"500"},
             create: {value:true}
         },
-        outputs:1,
+        inputs:1,
         icon: "message.png",
         label: function() {
-            return this.name||"posixmq-read";
+            return this.name||"posixmq-write";
         }
     });
 </script>
 
-<script type="text/x-red" data-template-name="posixmq-read">
+<script type="text/x-red" data-template-name="posixmq-write">
     <div class="form-row">
         <label for="node-input-msgname"><i class="icon-tag"></i> Queue Name</label>
         <input type="text" id="node-input-msgname" placeholder="msgname">
@@ -35,6 +35,6 @@
     </div>
 </script>
 
-<script type="text/x-red" data-help-name="posixmq-read">
-    <p>A simple node that receives message payloads from a Posix message queue</p>
+<script type="text/x-red" data-help-name="posixmq-write">
+    <p>A simple node that sends payloads to a Posix message queue</p>
 </script>

--- a/PosixMQ-write.html
+++ b/PosixMQ-write.html
@@ -6,7 +6,8 @@
             msgname: {value:"/events"},
             msgsize: {value:"256"},
             maxmsgs: {value:"500"},
-            create: {value:true}
+            create: {value:true},
+            ofprotect: {value:true}
         },
         inputs:1,
         icon: "message.png",
@@ -22,7 +23,7 @@
         <input type="text" id="node-input-msgname" placeholder="msgname">
     </div>
     <div class="form-row">
-        <label for="node-input-msgsize"><i class="icon-tag"></i> Create if necessary</label>
+        <label for="node-input-create"><i class="icon-tag"></i> Create if necessary</label>
         <input type="checkbox" id="node-input-create">
     </div>
     <div class="form-row">
@@ -32,6 +33,10 @@
     <div class="form-row">
         <label for="node-input-maxmsgs"><i class="icon-tag"></i> Maximum # of messages</label>
         <input type="text" id="node-input-maxmsgs" placeholder="maxmsgs">
+    </div>
+    <div class="form-row">
+        <label for="node-input-ofprotect"><i class="icon-tag"></i> Overflow Protection</label>
+        <input type="checkbox" id="node-input-ofprotect">
     </div>
 </script>
 

--- a/PosixMQ-write.js
+++ b/PosixMQ-write.js
@@ -14,7 +14,7 @@
 var PosixMQ = require('posix-mq');
 
 module.exports = function (RED) {    
-   function PosixMQReadNode(config) {
+   function PosixMQWriteNode(config) {
       RED.nodes.createNode(this, config);
       var posixmq = new PosixMQ();
       var node = this;
@@ -38,18 +38,16 @@ module.exports = function (RED) {
       node.status({ fill: "green", shape: "dot", text: config.msgname });
       readbuf = new Buffer(posixmq.msgsize);
 
-      posixmq.on('messages', () => {
-         var n;
-         while ((n = posixmq.shift(readbuf)) !== false) {
-            var str = readbuf.toString('utf8', 0, n);
-            node.send({ payload: str });
-         }
-      });
-      node.on('close', () => {
-         posixmq.close();
-         node.status({ fill: "red", shape: "dot", text: config.msgname });
-      });
-   }
-   RED.nodes.registerType("posixmq-read", PosixMQReadNode);
-};
-
+  node.on('input', function(msg) { 
+     if(msg.payload)
+     {
+      posixmq.push(Buffer.from(msg.payload));
+     }
+  });
+   
+  node.on('close', function() { 
+    posixmq.close();
+    node.status({fill: "red", shape: "dot", text: config.msgname});});
+ }
+ RED.nodes.registerType("posixmq-write", PosixMQWriteNode);
+}

--- a/PosixMQ-write.js
+++ b/PosixMQ-write.js
@@ -34,9 +34,7 @@ module.exports = function (RED) {
          node.status({ fill: "red", shape: "dot", text: config.msgname });
          return;
       }
-
       node.status({ fill: "green", shape: "dot", text: config.msgname });
-      readbuf = new Buffer(posixmq.msgsize);
 
   node.on('input', function(msg) { 
      if(msg.payload)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ Description
 This is a fork of Denis Francesconi's [PosixMQ-read](https://github.com/DE7GK35/PosixMQ-read) node for Node-RED.
 Uses Mike Okner's [posix-mq](https://github.com/mikeokner/posix-mq) library.
 
-The intent of this expansion is to allow the user to also send to a Message Queue as well as read from it.
-
-This is a work in progress.
+This version allows the user to both write to a POSIX message queue and read from a POSIX message queue.
 
 Requirements
 ============
@@ -23,13 +21,12 @@ Requirements
 
 Values
 ========
-
-(Pending Edit)
-
-![Values](https://raw.githubusercontent.com/DE7GK35/PosixMQ-read/master/editValues.png)
+These settings are applicable to both the posixmq-read and posixmq-write nodes.
 
 * **msgname** - _String_ - name of message queue.
 
 * **maxmsgs** - _Number_ - The maximum number of messages in the queue.
 
 * **msgsize** - _Number_ - The maximum size of messages in the queue.
+
+* **create** - _Boolean_ - Create the message queue if it is not already present.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 Description
 ===========
 
-![PosixMQ-flow](https://raw.githubusercontent.com/DE7GK35/PosixMQ-read/master/PosixMQ-flow.png)
+This is a fork of Denis Francesconi's [PosixMQ-read](https://github.com/DE7GK35/PosixMQ-read) node for Node-RED.
+Uses Mike Okner's [posix-mq](https://github.com/mikeokner/posix-mq) library.
 
-A [node.js](http://nodejs.org/) library for using POSIX message queues. Originally forked from mscdex/pmq to provide additional customization of flags passed to `mq_open()`. Subsequently re-written to support v4+ using [Native Abstractions for Node.js](https://github.com/nodejs/nan).
+The intent of this expansion is to allow the user to also send to a Message Queue as well as read from it.
 
+This is a work in progress.
 
 Requirements
 ============
@@ -19,14 +21,10 @@ Requirements
 
 * Depends on [nan](https://www.npmjs.com/package/nan) & [posix-mq](https://www.npmjs.com/package/posix-mq) which will be automatically installed when running `npm install posixmq-read`.
 
-Install
-=======
-
-```shell
-$ npm install posixmq-read
-```
 Values
 ========
+
+(Pending Edit)
 
 ![Values](https://raw.githubusercontent.com/DE7GK35/PosixMQ-read/master/editValues.png)
 
@@ -35,99 +33,3 @@ Values
 * **maxmsgs** - _Number_ - The maximum number of messages in the queue.
 
 * **msgsize** - _Number_ - The maximum size of messages in the queue.
-
-Examples
-========
-
-
-* Open an existing queue, read all of its messages, and then remove and close it:
-
-```javascript
-var PosixMQ = require('posix-mq');
-
-module.exports = function (RED) {    
- function PosixMQReadNode(config) {
-  RED.nodes.createNode(this,config);
-  this.msgname = config.msgname;
-  this.msgsize = Number(config.msgsize);
-  this.maxmsgs = Number(config.maxmsgs);
-  var posixmq = new PosixMQ();
-  var node = this;
-  var msg;
-  var n;
- 
-
-  var send = false;
-  posixmq.open({ name: node.msgname.toString(),create: true,mode: '0777',maxmsgs: node.maxmsgs, msgsize: node.msgsize });
-  node.status({fill: "green", shape: "dot", text: node.msgname.toString()});
-  node.warn("the " + node.msgname.toString() + " message queue is open");
-  readbuf = new Buffer(posixmq.msgsize);
-  node.on('input', function() { 
-     var str = "";
-     while ((n = posixmq.shift(readbuf)) !== false){
-      send = true;
-      str = str + readbuf.toString('utf8', 0, n);
-      };
-      if (send){node.send({payload: str})};
-      send = false;
-  });
-  node.on('close', function() { 
-    posixmq.unlink();
-    posixmq.close();
-    node.status({fill: "red", shape: "dot", text: node.msgname.toString()});});
- }
- RED.nodes.registerType("posixmq-read", PosixMQReadNode);
-}
-```
-
-
-
-API
-===
-
-Events
-------
-
-* **messages**() - Emitted every time the queue goes from empty to having at least one message.
-
-* **drain**() - Emitted when there is room for at least one message in the queue.
-
-Properties 
-----------------------
-
-* **isFull** - _boolean_ - Convenience property that returns true if `curmsgs` === `maxmsgs`.
-
-* **maxmsgs** - _integer_ - The maximum number of messages in the queue.
-
-* **msgsize** - _integer_ - The maximum size of messages in the queue.
-
-* **curmsgs** - _integer_ - The number of messages currently in the queue.
-
-Methods
--------
-
-* **(constructor)**() - Creates and returns a new PosixMQ instance.
-
-* **open**(<_object_>config) - _(void)_ - Connects to a queue. Valid properties in `config` are:
-
-    * name - _string_ - The name of the queue to open, it **MUST** start with a '/'.
-
-    * create - _boolean_ - Set to `true` to create the queue if it doesn't already exist (default is `false`). The queue will be owned by the user and group of the current process.
-
-    * exclusive - _boolean_ - If creating a queue, set to true if you want to ensure a queue with the given name does not already exist.
-
-    * mode - _mixed_ - If creating a queue, this is the permissions to use. This can be an octal string (e.g. '0777') or an integer.
-
-    * maxmsgs - _integer_ - If creating a queue, this is the maximum number of messages the queue can hold. This value is subject to the system limits in place and defaults to 10.
-
-    * msgsize - _integer_ - If creating a queue, this is the maximum size of each message (in bytes) in the queue. This value is subject to the system limits in place and defaults to 8192 bytes.
-
-    * flags - _integer_ - Default is `O_RDWR | O_NONBLOCK` (2050). If a different set of flags is required, its integer value may be provided here. See the man page for `mq_open` for more information.
-    
-* **close**() - _(void)_ - Disconnects from the queue.
-
-* **unlink**() - _(void)_ - Removes the queue from the system.
-
-* **push**(< _Buffer_ or _string_ >data[, < _integer_ >priority]) - _boolean_ - Pushes a message with the contents of `data` onto the queue with the optional `priority` (defaults to 0). `data` is either a string or Buffer object. `priority` is an integer between 0 and 31 inclusive.
-
-* **shift**(< _Buffer_ >readbuf[, < _boolean_ >returnTuple]) - _mixed_ - Shifts the next message off the queue and stores it in `readbuf`. If `returnTuple` is set to true, an array containing the number of bytes in the shifted message and the message's priority are returned, otherwise just the number of bytes is returned (default). If there was nothing on the queue, false is returned.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "node-red-contrib-posixmq",
+  "version": "0.2.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "nan": {
+      "version": "2.4.0",
+      "resolved": "http://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
+      "integrity": "sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI="
+    },
+    "posix-mq": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npmjs.org/posix-mq/-/posix-mq-1.0.2.tgz",
+      "integrity": "sha1-W3IK8T9kWYLVuT0lxh9vdZpV+7w=",
+      "requires": {
+        "nan": "2.4.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "dependencies": {
     "posix-mq": "1.0.2"
   },
-  "description": "A Node-RED node that receives messsages form a Posix message queue",
-  "name": "node-red-contrib-posixmq-read",
+  "description": "A Node-RED node to interact with Posix message queues",
+  "name": "node-red-contrib-posixmq",
   "node-red": {
     "nodes": {
-      "posixmq-read": "PosixMQ-read.js"
+      "posixmq-read": "PosixMQ-read.js",
+      "posixmq-write": "PosixMQ-write.js"
     }
   },
   "version": "0.2.0",
@@ -22,10 +23,13 @@
     "message",
     "queue"
   ],
-  "author": "Denis Francesconi",
+  "contributors": [
+    "Denis Francesconi",
+    "Jonathan Fether"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DE7GK35/PosixMQ-read.git"
+    "url": "git+https://github.com/jfether/node-red-posix-mq.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "posixmq-write": "PosixMQ-write.js"
     }
   },
-  "version": "0.2.2",
+  "version": "0.3.1",
   "main": "PosixMQ-read.js",
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "posixmq-write": "PosixMQ-write.js"
     }
   },
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "PosixMQ-read.js",
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "posixmq-write": "PosixMQ-write.js"
     }
   },
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "PosixMQ-read.js",
   "devDependencies": {},
   "scripts": {

--- a/todo
+++ b/todo
@@ -1,1 +1,3 @@
--make maxmsg and msgsize editable
+Elaborate a bit on the documentation
+Consider adding additional properties for control
+Consider improving the status of the node, so it reflects the status of the message queue as this changes.


### PR DESCRIPTION
I have improved the functionality of the node. It now is no longer a read-only function, but read/write. These are the changes in this pull request:

- Linked the actual configuration values to the parameters to posixmq.open()
- Wrapped posixmq.open() in try/catch so a failure to open would result in a red status on the node.
- Removed some debug lines
- Queue is not unlinked by default on node removal (TODO: Consider adding this in as a config option)
- Add a respective posixmq-write node to send messages to a queue
- Removed dependency on input to probe for pending messages. Messages are emitted as they appear in the queue.
- Removed input from PosixMQ-read node; it only has an output.
